### PR TITLE
Getting the message payload within the try/catch

### DIFF
--- a/exn-connector/src/main/groovy/eu/nebulouscloud/exn/core/Consumer.groovy
+++ b/exn-connector/src/main/groovy/eu/nebulouscloud/exn/core/Consumer.groovy
@@ -71,10 +71,9 @@ class Consumer extends Link<Receiver>{
 
     protected void onDelivery(Delivery delivery, Context context){
         logger.debug("Default on delivery for delivery for {}",this.linkAddress)
-        Message message = delivery.message();
-
-        Map body = this.processMessage(message, context)
         try {
+            Message message = delivery.message();
+            Map body = this.processMessage(message, context)
             this.handler.onMessage(
                     this.key,
                     this.address,


### PR DESCRIPTION
This fix just moves the message delivery inside the try catch to avoid uncaught runtime exceptions
